### PR TITLE
Update approve-dependabot-pr.yml

### DIFF
--- a/.github/workflows/approve-dependabot-pr.yml
+++ b/.github/workflows/approve-dependabot-pr.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
     uses: devops-actions/.github/.github/workflows/approve-dependabot-pr.yml@main
     #secrets:
     #  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/approve-dependabot-pr.yml` file. The change adds write permissions for `actions` under `permissions:`. This will allow the GitHub Actions workflow to have write access to the repository's actions.