### PR TITLE
Update approve-dependabot-pr.yml

### DIFF
--- a/.github/workflows/approve-dependabot-pr.yml
+++ b/.github/workflows/approve-dependabot-pr.yml
@@ -12,5 +12,5 @@ jobs:
       pull-requests: write
       actions: write
     uses: devops-actions/.github/.github/workflows/approve-dependabot-pr.yml@main
-    #secrets:
-    #  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes a change in the `.github/workflows/approve-dependabot-pr.yml` file. The change involves the uncommenting and renaming of the secrets section, specifically the `GITHUB_TOKEN`. The `GITHUB_TOKEN` has been renamed to `GH_TOKEN`.

In detail:

* [`.github/workflows/approve-dependabot-pr.yml`](diffhunk://#diff-e6f85d1989f1ca060a5f603b6b16deeda1033b0bf6852dc431d482b485c99ce2L15-R16): Uncommented the secrets section and renamed `GITHUB_TOKEN` to `GH_TOKEN`. This change might have been made to standardize the token naming across the project or to resolve a conflict with another usage of `GITHUB_TOKEN`.