### PR TITLE
Use GitHub App instead of a PAT

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -10,7 +10,5 @@ jobs:
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       
-      - name: Check workflow files
-        uses: docker://rhysd/actionlint@sha256:5f957b2a08d223e48133e1a914ed046bea12e578fe2f6ae4de47fdbe691a2468 # 1.6.22
-        with:
-          args: -color
+      - name: Check workflow files for linting errors
+        uses: devops-actions/actionlint@e7ee33fbf5aa8c9f9ee1145137f3e52e25d6a35b #v0.1.3

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -16,12 +16,19 @@ jobs:
   test-from-organization:
     runs-on: ubuntu-latest
     steps:
+      - name: Get GitHub Application Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@dc0413987a085fa17d19df9e47d4677cf81ffef3 # v3
+        with:
+          application_id: ${{ vars.DEVOPS_ACTIONS_APPLICATION_ID }}
+          application_private_key: ${{ secrets.DEVOPS_ACTIONS_APPLICATION_KEY }}
+
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       
       - uses: ./
         id: load-runner-info-org
         with: 
-          accessToken: ${{ secrets.PAT }}
+          accessToken: ${{ steps.get_workflow_token.outputs.token }}
           organization: ${{ env.organization }}
 
       - name: Store output in result files
@@ -92,6 +99,13 @@ jobs:
         id: tag
         uses: devops-actions/action-get-tag@19f393df16cb09284484fb49bf678004bf50896a # v1.0.1
 
+      - name: Get GitHub Application Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@dc0413987a085fa17d19df9e47d4677cf81ffef3 # v3
+        with:
+          application_id: ${{ vars.DEVOPS_ACTIONS_APPLICATION_ID }}
+          application_private_key: ${{ secrets.DEVOPS_ACTIONS_APPLICATION_KEY }}
+
       # publish a release with the build assets
       - uses: rajbos-actions/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         id: publish
@@ -100,7 +114,7 @@ jobs:
           tag_name: ${{ github.ref }}
           body: Release ${{ steps.tag.outputs.tag }} is available now
           files: ./dist/main.js
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.get_workflow_token.outputs.token }}
 
       - run: |
           echo "$url"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,11 +29,18 @@ jobs:
   test-from-organization:
     runs-on: ubuntu-latest
     steps:
+      - name: Get GitHub Application Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@dc0413987a085fa17d19df9e47d4677cf81ffef3 # v3
+        with:
+          application_id: ${{ vars.DEVOPS_ACTIONS_APPLICATION_ID }}
+          application_private_key: ${{ secrets.DEVOPS_ACTIONS_APPLICATION_KEY }}
+
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v2.5.0
       - uses: ./
         id: load-runner-info-org
         with: 
-          accessToken: ${{ secrets.PAT }}
+          accessToken: ${{ steps.get_workflow_token.outputs.token }}
           organization: ${{ env.organization }}
 
       - name: Store output in result files


### PR DESCRIPTION
This pull request primarily focuses on improving the security of the GitHub Actions workflows in the `.github/workflows/publishing.yml` and `.github/workflows/testing.yml` files. The changes replace the use of a Personal Access Token (PAT) with a GitHub Application Token, which is more secure and provides more granular control over permissions.

Here are the key changes:

* `.github/workflows/publishing.yml` and `.github/workflows/testing.yml`: Introduced a new step to get a GitHub Application Token using the `peter-murray/workflow-application-token-action` action. This token is generated using the `DEVOPS_ACTIONS_APPLICATION_ID` and `DEVOPS_ACTIONS_APPLICATION_KEY` variables. [[1]](diffhunk://#diff-60ae0e3ad4084f4b39a8659e9ee0c139ef43cfb21d7ffa25758615d246b1ff26R19-R31) [[2]](diffhunk://#diff-60ae0e3ad4084f4b39a8659e9ee0c139ef43cfb21d7ffa25758615d246b1ff26R102-R108) [[3]](diffhunk://#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dR32-R43)

* `.github/workflows/publishing.yml` and `.github/workflows/testing.yml`: Replaced the use of the `PAT` secret with the newly generated GitHub Application Token in the `accessToken` parameter of the `load-runner-info-org` step and in the `token` parameter of the `rajbos-actions/action-gh-release` action. [[1]](diffhunk://#diff-60ae0e3ad4084f4b39a8659e9ee0c139ef43cfb21d7ffa25758615d246b1ff26R19-R31) [[2]](diffhunk://#diff-60ae0e3ad4084f4b39a8659e9ee0c139ef43cfb21d7ffa25758615d246b1ff26L103-R117) [[3]](diffhunk://#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dR32-R43)

These changes enhance the security of the workflows by limiting the scope of the tokens used, reducing the risk of unauthorized access.