### PR TITLE
fix: correct inverted git status condition in update-dist job

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Commit changes if any
         run: |
-          if [ -z "$(git status --porcelain)" ]; then 
+          if [ -n "$(git status --porcelain)" ]; then 
             echo "Found changes to commit"
             git config --global user.email "github-actions[bot]@users.noreply.github.com"
             git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary

Fixes the `update-dist` job in `.github/workflows/build-check.yml` which never committed dist changes due to an inverted shell condition.

## Root cause

`[ -z "$(git status --porcelain)" ]` is true when the working tree is **clean** (empty output), so the git add/commit/push block only ran when there was nothing to commit.

## Fix

Changed `-z` to `-n` -- the block now runs when `git status --porcelain` returns a non-empty string (changes actually exist).

Closes #632