### PR TITLE
Fix check-for-release workflow when labels are missing

### DIFF
--- a/.github/workflows/check-for-release.yml
+++ b/.github/workflows/check-for-release.yml
@@ -371,16 +371,56 @@ jobs:
           Once the release is published, this issue can be closed.
           "@
           
-          # Determine labels
-          $labels = @("release", "automated")
+          # Ensure the workflow labels exist before creating the issue
+          $labelDefinitions = @(
+            @{
+              Name = "release"
+              Color = "5319e7"
+              Description = "Issues and pull requests related to releasing"
+            },
+            @{
+              Name = "automated"
+              Color = "1d76db"
+              Description = "Created or updated by automation"
+            }
+          )
           if ("${{ steps.needs-release.outputs.has_security_updates }}" -eq "true") {
-            $labels += "security"
+            $labelDefinitions += @{
+              Name = "security"
+              Color = "d93f0b"
+              Description = "Security-related work"
+            }
           }
-          
-          # Create the issue
-          $labelsArg = ($labels | ForEach-Object { "--label `"$_`"" }) -join " "
-          
-          Invoke-Expression "gh issue create --title `"🚀 Release ${{ steps.new-version.outputs.newtag }}`" --body `$body $labelsArg"
+
+          $existingLabels = @(
+            gh label list --limit 200 --json name |
+              ConvertFrom-Json |
+              Select-Object -ExpandProperty name
+          )
+
+          foreach ($labelDefinition in $labelDefinitions) {
+            if ($labelDefinition.Name -notin $existingLabels) {
+              & gh label create $labelDefinition.Name --color $labelDefinition.Color --description $labelDefinition.Description
+            }
+          }
+
+          $bodyPath = Join-Path $PWD "release-issue-body.md"
+          $body | Out-File -FilePath $bodyPath -Encoding utf8
+
+          $issueArgs = @(
+            "issue",
+            "create",
+            "--title",
+            "🚀 Release ${{ steps.new-version.outputs.newtag }}",
+            "--body-file",
+            $bodyPath
+          )
+
+          foreach ($labelDefinition in $labelDefinitions) {
+            $issueArgs += @("--label", $labelDefinition.Name)
+          }
+
+          & gh @issueArgs
           
           echo "✅ Release issue created" >> $env:GITHUB_STEP_SUMMARY
 

--- a/__tests__/workflow.test.ts
+++ b/__tests__/workflow.test.ts
@@ -33,3 +33,31 @@ test('publishing workflow includes SBOM generation', () => {
   expect(releaseStep.with.files).toContain('sbom.spdx.json')
   expect(releaseStep.with.body).toContain('SBOM')
 })
+
+test('check-for-release workflow provisions labels before creating a release issue', () => {
+  const workflowPath = path.resolve('.github/workflows/check-for-release.yml')
+  expect(fs.existsSync(workflowPath)).toBe(true)
+
+  const workflowContent = fs.readFileSync(workflowPath, 'utf8')
+  const workflow = yaml.load(workflowContent) as any
+
+  expect(workflow).toBeDefined()
+  expect(workflow.jobs).toBeDefined()
+  expect(workflow.jobs['check-time-for-new-release']).toBeDefined()
+
+  const checkJob = workflow.jobs['check-time-for-new-release']
+  expect(checkJob.steps).toBeDefined()
+
+  const releaseIssueStep = checkJob.steps.find(
+    (step: any) => step.name === 'Create release issue'
+  )
+
+  expect(releaseIssueStep).toBeDefined()
+  expect(releaseIssueStep.run).toContain('gh label list --limit 200 --json name')
+  expect(releaseIssueStep.run).toContain('Name = "release"')
+  expect(releaseIssueStep.run).toContain('Name = "automated"')
+  expect(releaseIssueStep.run).toContain('Name = "security"')
+  expect(releaseIssueStep.run).toContain('& gh label create')
+  expect(releaseIssueStep.run).toContain('--body-file')
+  expect(releaseIssueStep.run).not.toContain('Invoke-Expression')
+})


### PR DESCRIPTION
The scheduled `check-for-release` workflow is failing in the "Create release issue" step when the repository does not already have the labels it expects. This change makes that path self-healing so the release check can open the issue instead of aborting on a missing-label error.

## What changed

- bootstrap the expected `release`, `automated`, and conditional `security` labels before calling `gh issue create`
- replace the `Invoke-Expression` call with a safer argument-array invocation that uses `--body-file`
- add a regression test that verifies the workflow provisions labels and no longer relies on `Invoke-Expression`

## Notes

The SBOM generation step remains non-blocking because it already uses `continue-on-error`. The blocking failure addressed here was the missing-label error in the release issue step.