### PR TITLE
security: add explicit permissions to semver-check workflow

### DIFF
--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -5,6 +5,10 @@ on:
       - '*'
   workflow_dispatch:
 
+# Declare default GITHUB_TOKEN permissions as read only.
+permissions:
+  contents: read
+
 jobs:
   semver:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
Adds a top-level permissions: contents: read block to .github/workflows/semver-check.yml, which previously had no permissions declared at all (defaulting to the repo-wide GITHUB_TOKEN default, which may be broader than needed).

## Why
Resolves open code scanning alerts:
- #113 ctions/missing-workflow-permissions (CodeQL)
- #109 Token-Permissions (OpenSSF Scorecard) - "no topLevel permission defined"

## Note on other open Token-Permissions alerts
The 4 remaining open Token-Permissions alerts (#108 publishing.yml, #81 approve-dependabot-pr.yml, #80 actions-dependencies.yml, #30 ossf-analysis.yml) are flagged because their jobs declare job-level write scopes (contents, pull-requests, ctions, security-events). These are already minimally scoped and required by the shared devops-actions/.github reusable workflows they call (release publishing, dependabot auto-approve/merge, dependency graph submission, SARIF upload). Reducing them further would break those workflows. Scorecard's Token-Permissions check inherently scores any job-level write permission as 0 regardless of justification, so these are expected/accepted and not addressed in this PR.